### PR TITLE
Revert ":arrow_up: Upgrades QEMU to v2.11.0 (#1)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ defaults: &defaults
       - run:
           name: Get QEMU user mode processor emulation binaries
           command: |
-            curl -L -s "https://github.com/hassio-addons/qemu-user-static/releases/download/v2.11.0/qemu-aarch64-static.tar.gz" | tar zxvf - -C ./base/rootfs/usr/bin/
-            curl -L -s "https://github.com/hassio-addons/qemu-user-static/releases/download/v2.11.0/qemu-arm-static.tar.gz" | tar zxvf - -C ./base/rootfs/usr/bin/
+            curl -L -s "https://github.com/hassio-addons/qemu-user-static/releases/download/v2.10.1/qemu-aarch64-static.tar.gz" | tar zxvf - -C ./base/rootfs/usr/bin/
+            curl -L -s "https://github.com/hassio-addons/qemu-user-static/releases/download/v2.10.1/qemu-arm-static.tar.gz" | tar zxvf - -C ./base/rootfs/usr/bin/
       - deploy:
           name: Build and (maybe) deploy
           command: |


### PR DESCRIPTION
This reverts commit fc588741e7640f52b325acbf986457dcec101f9e.

# Proposed Changes

Reverts the upgrade to QEMU v2.11.0

This version seems to have an issue with GLIBC based distributions (again), this time on ARMHF.
