### PR TITLE
Upgrade bashio to v0.7.1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -42,7 +42,7 @@ RUN \
     && mkdir -p /etc/services.d \
     \
     && curl -J -L -o /tmp/bashio.tar.gz \
-        "https://github.com/hassio-addons/bashio/archive/v0.6.0.tar.gz" \
+        "https://github.com/hassio-addons/bashio/archive/v0.7.1.tar.gz" \
     && mkdir /tmp/bashio \
     && tar zxvf \
         /tmp/bashio.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Upgrade bashio to v0.7.1 to up to date.