### PR TITLE
Upgrade Bashio to v0.10.1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -44,7 +44,7 @@ RUN \
     && mkdir -p /etc/services.d \
     \
     && curl -J -L -o /tmp/bashio.tar.gz \
-        "https://github.com/hassio-addons/bashio/archive/v0.9.0.tar.gz" \
+        "https://github.com/hassio-addons/bashio/archive/v0.10.1.tar.gz" \
     && mkdir /tmp/bashio \
     && tar zxvf \
         /tmp/bashio.tar.gz \

--- a/base/rootfs/etc/cont-init.d/00-banner.sh
+++ b/base/rootfs/etc/cont-init.d/00-banner.sh
@@ -12,7 +12,7 @@ if bashio::supervisor.ping; then
         '-----------------------------------------------------------'
 
     bashio::log.blue " Add-on version: $(bashio::addon.version)"
-    if bashio::addon.update_available; then
+    if bashio::var.true "$(bashio::addon.update_available)"; then
         bashio::log.magenta ' There is an update available for this add-on!'
         bashio::log.magenta \
             " Latest add-on version: $(bashio::addon.version_latest)"
@@ -21,7 +21,7 @@ if bashio::supervisor.ping; then
         bashio::log.green ' You are running the latest version of this add-on.'
     fi
 
-    bashio::log.blue " System: $(bashio::host.operating_system)" \
+    bashio::log.blue " System: $(bashio::info.operating_system)" \
         " ($(bashio::info.arch) / $(bashio::info.machine))"
     bashio::log.blue " Home Assistant Core: $(bashio::info.homeassistant)"
     bashio::log.blue " Home Assistant Supervisor: $(bashio::info.supervisor)"


### PR DESCRIPTION
# Proposed Changes

Upgrades Bashio to v0.10.1

Release notes:

- <https://github.com/hassio-addons/bashio/releases/tag/v0.10.0>
- <https://github.com/hassio-addons/bashio/releases/tag/v0.10.1>
