### PR TITLE
:arrow_down: Downgrade S6 Overlay to v2.1.0.2

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "armv7" ]; then S6_ARCH="arm"; fi \
     && if [ "${BUILD_ARCH}" = "armhf" ]; then S6_ARCH="armhf"; fi \
     \
-    && curl -L "https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.1/s6-overlay-${S6_ARCH}.tar.gz" \
+    && curl -L "https://github.com/just-containers/s6-overlay/releases/download/v2.1.0.2/s6-overlay-${S6_ARCH}.tar.gz" \
         | tar zxvf - -C / \
     \
     && mkdir -p /etc/fix-attrs.d \


### PR DESCRIPTION
# Proposed Changes

Downgrade S6 Overlay to v2.1.0.2

## Related Issues

https://github.com/just-containers/s6-overlay/issues/324
