### PR TITLE
⬆️ Upgrades Debian Buster to 20210721

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=debian:buster-20210621-slim
+ARG BUILD_FROM=debian:buster-20210721-slim
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/base/build.json
+++ b/base/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "arm64v8/debian:buster-20210621-slim",
-    "amd64": "amd64/debian:buster-20210621-slim",
-    "armhf": "arm32v5/debian:buster-20210621-slim",
-    "armv7": "arm32v7/debian:buster-20210621-slim",
-    "i386": "i386/debian:buster-20210621-slim"
+    "aarch64": "arm64v8/debian:buster-20210721-slim",
+    "amd64": "amd64/debian:buster-20210721-slim",
+    "armhf": "arm32v5/debian:buster-20210721-slim",
+    "armv7": "arm32v7/debian:buster-20210721-slim",
+    "i386": "i386/debian:buster-20210721-slim"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Upgrades Debian Buster to 20210721
