### PR TITLE
Configure timezone automatically

### DIFF
--- a/base/rootfs/etc/cont-init.d/02-set-timezone.sh
+++ b/base/rootfs/etc/cont-init.d/02-set-timezone.sh
@@ -4,7 +4,7 @@
 # Configures the timezone
 # ==============================================================================
 
-if bashio::var.not_empty "${TZ}"; then
+if ! bashio::var.is_empty "${TZ}"; then
     bashio::log.info "Configuring timezone"
 
     ln --symbolic --no-dereference --force "/usr/share/zoneinfo/${TZ}" /etc/localtime

--- a/base/rootfs/etc/cont-init.d/02-set-timezone.sh
+++ b/base/rootfs/etc/cont-init.d/02-set-timezone.sh
@@ -1,9 +1,8 @@
-#!/usr/bin/with-contenv bashio
+#!/command/with-contenv bashio
 # ==============================================================================
 # Home Assistant Community Add-on: Base Images
 # Configures the timezone
 # ==============================================================================
-
 if ! bashio::var.is_empty "${TZ}"; then
     bashio::log.info "Configuring timezone"
 

--- a/base/rootfs/etc/cont-init.d/02-set-timezone.sh
+++ b/base/rootfs/etc/cont-init.d/02-set-timezone.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Home Assistant Community Add-on: Base Images
+# Configures the timezone
+# ==============================================================================
+
+if bashio::var.not_empty "${TZ}"; then
+    bashio::log.info "Configuring timezone"
+
+    ln --symbolic --no-dereference --force "/usr/share/zoneinfo/${TZ}" /etc/localtime
+    echo "${TZ}" > /etc/timezone
+fi


### PR DESCRIPTION
# Proposed Changes

Properly configure the timezone for the container on the addon startup.

Some applications seems to rely on TZ environment variable, which gets automatically injected by the HA Supervisor into the container.

However, some other applications rely on `/etc/localtime` or `/etc/timezone`, which is what this PR fixes.

## Related Issues

Fixes https://github.com/TECH7Fox/asterisk-hass-addons/issues/115
