### PR TITLE
Do not delay the startup when not running as addon

### DIFF
--- a/base/rootfs/etc/cont-init.d/00-banner.sh
+++ b/base/rootfs/etc/cont-init.d/00-banner.sh
@@ -5,7 +5,7 @@
 # ==============================================================================
 
 # Exits early if not running as an add-on
-if bashio::var.is_empty "${SUPERVISOR_TOKEN}"; then
+if bashio::var.is_empty "${SUPERVISOR_TOKEN:-}"; then
     exit
 fi
 

--- a/base/rootfs/etc/cont-init.d/00-banner.sh
+++ b/base/rootfs/etc/cont-init.d/00-banner.sh
@@ -3,6 +3,12 @@
 # Home Assistant Community Add-on: Base Images
 # Displays a simple add-on banner on startup
 # ==============================================================================
+
+# Exits early if not running as an add-on
+if bashio::var.is_empty "${SUPERVISOR_TOKEN}"; then
+    exit
+fi
+
 if bashio::supervisor.ping; then
     bashio::log.blue \
         '-----------------------------------------------------------'

--- a/base/rootfs/etc/cont-init.d/01-log-level.sh
+++ b/base/rootfs/etc/cont-init.d/01-log-level.sh
@@ -3,6 +3,12 @@
 # Home Assistant Community Add-on: Base Images
 # Sets the log level correctly
 # ==============================================================================
+
+# Exits early if not running as an add-on
+if bashio::var.is_empty "${SUPERVISOR_TOKEN}"; then
+    exit
+fi
+
 declare log_level
 
 # Check if the log level configuration option exists

--- a/base/rootfs/etc/cont-init.d/01-log-level.sh
+++ b/base/rootfs/etc/cont-init.d/01-log-level.sh
@@ -5,7 +5,7 @@
 # ==============================================================================
 
 # Exits early if not running as an add-on
-if bashio::var.is_empty "${SUPERVISOR_TOKEN}"; then
+if bashio::var.is_empty "${SUPERVISOR_TOKEN:-}"; then
     exit
 fi
 


### PR DESCRIPTION
# Proposed Changes

When the image is not being run as a Home Assistant add-on, there's no point in waiting `ping` to fail or anything else that's Home Assistant specific.

This is how it is today:


https://user-images.githubusercontent.com/29582865/201720371-5f1b52e1-327a-4267-814b-6920c5fa3aac.mp4



## Related Issues

- https://github.com/blakeblackshear/frigate/pull/4393
- https://github.com/AlexxIT/go2rtc/pull/72