### PR TITLE
Fix unbound TZ variable

### DIFF
--- a/base/rootfs/etc/cont-init.d/02-set-timezone.sh
+++ b/base/rootfs/etc/cont-init.d/02-set-timezone.sh
@@ -3,9 +3,8 @@
 # Home Assistant Community Add-on: Base Images
 # Configures the timezone
 # ==============================================================================
-if ! bashio::var.is_empty "${TZ:-}"; then
-    bashio::log.info "Configuring timezone"
 
-    ln --symbolic --no-dereference --force "/usr/share/zoneinfo/${TZ}" /etc/localtime
-    echo "${TZ}" > /etc/timezone
-fi
+bashio::log.info "Configuring timezone"
+
+ln --symbolic --no-dereference --force "/usr/share/zoneinfo/${TZ}" /etc/localtime
+echo "${TZ}" > /etc/timezone

--- a/base/rootfs/etc/cont-init.d/02-set-timezone.sh
+++ b/base/rootfs/etc/cont-init.d/02-set-timezone.sh
@@ -3,7 +3,7 @@
 # Home Assistant Community Add-on: Base Images
 # Configures the timezone
 # ==============================================================================
-if ! bashio::var.is_empty "${TZ}"; then
+if ! bashio::var.is_empty "${TZ:-}"; then
     bashio::log.info "Configuring timezone"
 
     ln --symbolic --no-dereference --force "/usr/share/zoneinfo/${TZ}" /etc/localtime


### PR DESCRIPTION
# Proposed Changes

This happens when the TZ environment variable is not set. Without this the whole line is meaningless.

However, if this is only meant to be running from within Home Assistant Supervisor, we can also remove the whole check, as TZ will be always present.

## Related Issues

- https://github.com/blakeblackshear/frigate/pull/4393
