### PR TITLE
:arrow_up: Upgrades Debian to Bullseye 20221205

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=debian:bullseye-20221024-slim
+ARG BUILD_FROM=debian:bullseye-20221205-slim
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/base/build.yaml
+++ b/base/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  aarch64: arm64v8/debian:bullseye-20221024-slim
-  amd64: amd64/debian:bullseye-20221024-slim
-  armhf: arm32v5/debian:bullseye-20221024-slim
-  armv7: arm32v7/debian:bullseye-20221024-slim
-  i386: i386/debian:bullseye-20221024-slim
+  aarch64: arm64v8/debian:bullseye-20221205-slim
+  amd64: amd64/debian:bullseye-20221205-slim
+  armhf: arm32v5/debian:bullseye-20221205-slim
+  armv7: arm32v7/debian:bullseye-20221205-slim
+  i386: i386/debian:bullseye-20221205-slim
 codenotary:
   signer: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes

Upgrades the Debian Bullseye base image to 20221205
