### PR TITLE
remove breaking line

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,7 +6,6 @@ FROM ${BUILD_FROM}
 ENV \
     CARGO_NET_GIT_FETCH_WITH_CLI=true \
     DEBIAN_FRONTEND="noninteractive" \
-    HOME="/root" \
     LANG="C.UTF-8" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \


### PR DESCRIPTION
# Proposed Changes

The removed line basically forces derivative addons to run as root.  The default expected behavior for the root user is to resolve to /root and to /home/[user] for other users. With this line all users resolve to /root causing failures.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfile configuration by removing the HOME environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->